### PR TITLE
Allow 'title' to be overridden

### DIFF
--- a/src/apis/avantation.ts
+++ b/src/apis/avantation.ts
@@ -14,6 +14,7 @@ const YAML: any = require('json2yaml');
 
 export class AvantationAPI implements Avantation.InputConfig {
     har: HAR.Final;
+    title: string;
     template: OAS.Template;
     host: string;
     basePath: string;
@@ -31,6 +32,7 @@ export class AvantationAPI implements Avantation.InputConfig {
 
     constructor(input: Avantation.InputConfig, oclif: any) {
         this.har = input.har;
+        this.title = input.title;
         this.host = input.host;
         this.basePath = input.basePath;
         this.pathParamRegex = input.pathParamRegex;
@@ -49,7 +51,7 @@ export class AvantationAPI implements Avantation.InputConfig {
 
     private async run() {
         this.har.log.entries.forEach(this.buildEntry.bind(this));
-        this.onBuildComplete(this.template);
+        this.onBuildComplete();
     }
 
     logSuccess(head: string): void {
@@ -381,7 +383,7 @@ export class AvantationAPI implements Avantation.InputConfig {
         ];
     }
 
-    onBuildComplete(openapi: OAS.Template): void {
+    onBuildComplete(): void {
         if (!this.template.tags) this.template.tags = [];
 
         if (!this.disableTag)
@@ -392,6 +394,8 @@ export class AvantationAPI implements Avantation.InputConfig {
             }
 
         let that = this;
+        this.template.info.title = that.title;
+
         this.template.servers.forEach(function (server: OAS.ServerObject) {
             server.url = server.url.replace('{host}', that.host);
             if (server.variables && server.variables.basePath && typeof server.variables.basePath == 'object') {

--- a/src/apis/util.ts
+++ b/src/apis/util.ts
@@ -1,5 +1,5 @@
 import * as HAR from '../interfaces/har';
-import * as GenerateSchema from './json.js';
+import GenerateSchema from './json.js';
 export namespace Util {
     export function generateSchema(input: any): any {
         let schema = GenerateSchema(input)

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ class Avantation extends Command {
             : "";
         var input: AvantationInterface.InputConfig = {
             har: har,
+            title: "Avantation REST Template",
             host: host,
             basePath: flags['base-path'] || '',
             template: template,

--- a/src/interfaces/avantation.ts
+++ b/src/interfaces/avantation.ts
@@ -48,6 +48,7 @@ export interface build {
 
 export interface InputConfig {
     har: HAR.Final;
+    title: string;
     host: string;
     basePath: string;
     template: OAS.Template;

--- a/src/templates/avantation.ts
+++ b/src/templates/avantation.ts
@@ -2,7 +2,7 @@ let defaultTemplate: any = {
     openapi: '3.0.0',
     info: {
         version: '1.0',
-        title: 'Avantation REST Template',
+        title: '{title}',
         description: 'TODO: Add Description'
     },
     servers: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "lib",


### PR DESCRIPTION
* This change is only at the API level for now (no CLI flag)

Set `esModuleInterop` to `true`

* This fixes some typescript build errors caused by `GenerateSchema` import